### PR TITLE
Fix indentation causing syntax error

### DIFF
--- a/gui/grilla_widget.py
+++ b/gui/grilla_widget.py
@@ -815,7 +815,7 @@ class GrillaWidget(QWidget):
                 self._ptz_error_count = getattr(self, '_ptz_error_count', 0) + 1
                 if self._ptz_error_count <= 3:
                     self.registrar_log(f"⚠️ Error integración PTZ: {e}")
-self.request_paint_update()
+        self.request_paint_update()
 
     def actualizar_pixmap_y_frame(self, frame):
         if not frame.isValid():


### PR DESCRIPTION
## Summary
- correct indentation in `grilla_widget.py` to avoid `IndentationError`

## Testing
- `python -m py_compile gui/grilla_widget.py`


------
https://chatgpt.com/codex/tasks/task_e_685c2827641c832d922a3d15fa7d368e