### PR TITLE
Fix PTZ initialization call

### DIFF
--- a/gui/grilla_widget.py
+++ b/gui/grilla_widget.py
@@ -815,7 +815,7 @@ class GrillaWidget(QWidget):
                 self._ptz_error_count = getattr(self, '_ptz_error_count', 0) + 1
                 if self._ptz_error_count <= 3:
                     self.registrar_log(f"⚠️ Error integración PTZ: {e}")
-self.request_paint_update()
+        self.request_paint_update()
 
     def actualizar_pixmap_y_frame(self, frame):
         if not frame.isValid():

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -136,7 +136,8 @@ class MainGUI(QMainWindow):
         self.ptz_detection_bridge = None
         self.ptz_system = None
         if PTZ_AVAILABLE:
-            self._initialize_ptz_system()
+            # Metodo de inicialización actualizado
+            self.initialize_ptz_system()
 
 
     def _setup_ptz_menu(self):


### PR DESCRIPTION
## Summary
- ensure PTZ initialization uses existing `initialize_ptz_system` method

## Testing
- `python -m py_compile ui/main_window.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests' / PyQt6)*

------
https://chatgpt.com/codex/tasks/task_e_685c2827641c832d922a3d15fa7d368e