### PR TITLE
Implement absolute PTZ moves

### DIFF
--- a/core/ptz_control.py
+++ b/core/ptz_control.py
@@ -44,6 +44,21 @@ class PTZCameraONVIF:
         }
         self.ptz.ContinuousMove(req)
 
+    def absolute_move(self, pan: float, tilt: float, zoom: float, speed: float | None = None):
+        """Mover la cámara a una posición absoluta."""
+        req = self.ptz.create_type('AbsoluteMove')
+        req.ProfileToken = self.profile_token
+        req.Position = {
+            'PanTilt': {'x': max(-1.0, min(1.0, pan)), 'y': max(-1.0, min(1.0, tilt))},
+            'Zoom': {'x': max(0.0, min(1.0, zoom))}
+        }
+        if speed is not None:
+            req.Speed = {
+                'PanTilt': {'x': speed, 'y': speed},
+                'Zoom': {'x': speed}
+            }
+        self.ptz.AbsoluteMove(req)
+
     def stop(self):
         self.ptz.Stop({'ProfileToken': self.profile_token})
 

--- a/test/test_ptz_absolute_move.py
+++ b/test/test_ptz_absolute_move.py
@@ -1,0 +1,66 @@
+import unittest
+from types import SimpleNamespace
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from core.multi_object_ptz_system import MultiObjectPTZTracker, MultiObjectConfig
+
+class MockPTZService:
+    def __init__(self, with_absolute=True):
+        self.with_absolute = with_absolute
+        self.last_move = None
+    def create_type(self, name):
+        return SimpleNamespace(ProfileToken=None, Position=None, Velocity=None)
+    if hasattr(SimpleNamespace, 'AbsoluteMove'):
+        pass
+    def AbsoluteMove(self, req):
+        if self.with_absolute:
+            self.last_move = ('Absolute', req)
+        else:
+            raise AttributeError('AbsoluteMove not supported')
+    def ContinuousMove(self, req):
+        self.last_move = ('Continuous', req)
+    def GetStatus(self, req):
+        return SimpleNamespace(Position=SimpleNamespace(PanTilt=SimpleNamespace(x=0.0, y=0.0), Zoom=SimpleNamespace(x=0.0)))
+
+class MockPTZServiceNoAbs:
+    def __init__(self):
+        self.last_move = None
+    def create_type(self, name):
+        return SimpleNamespace(ProfileToken=None, Position=None, Velocity=None)
+    def ContinuousMove(self, req):
+        self.last_move = ('Continuous', req)
+    def GetStatus(self, req):
+        return SimpleNamespace(Position=SimpleNamespace(PanTilt=SimpleNamespace(x=0.0, y=0.0), Zoom=SimpleNamespace(x=0.0)))
+
+class MockCamera:
+    def __init__(self):
+        self.calls = []
+    def absolute_move(self, pan, tilt, zoom, speed=None):
+        self.calls.append((pan, tilt, zoom))
+    def continuous_move(self, pan, tilt, zoom_speed=0.0):
+        self.calls.append(('cont', pan, tilt))
+
+class AbsoluteMoveTests(unittest.TestCase):
+    def test_service_absolute_move_used(self):
+        cfg = MultiObjectConfig(use_absolute_move=True)
+        tracker = MultiObjectPTZTracker('0.0.0.0', 80, 'u', 'p', multi_config=cfg)
+        tracker.ptz_service = MockPTZService()
+        tracker.profile_token = 't'
+        tracker._send_ptz_command(0.5, -0.2)
+        self.assertEqual(tracker.ptz_service.last_move[0], 'Absolute')
+
+    def test_camera_absolute_move_fallback(self):
+        cfg = MultiObjectConfig(use_absolute_move=True)
+        tracker = MultiObjectPTZTracker('0.0.0.0', 80, 'u', 'p', multi_config=cfg)
+        tracker.ptz_service = MockPTZServiceNoAbs()
+        tracker.camera = MockCamera()
+        tracker.profile_token = 't'
+        tracker._send_ptz_command(0.3, 0.1)
+        self.assertTrue(tracker.camera.calls)
+        self.assertEqual(tracker.camera.calls[0][0], tracker.current_pan_position)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `absolute_move` to `PTZCameraONVIF`
- track current PTZ position in `MultiObjectPTZTracker`
- add optional `use_absolute_move` config
- implement absolute move logic and reset on stop
- add unit tests for absolute move behavior

## Testing
- `pytest test/test_ptz_absolute_move.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: requests, PyQt6)*

------
https://chatgpt.com/codex/tasks/task_e_685c435779e0832db5c3f7b5b39f10b6