### PR TITLE
Remove pointless hasattr block

### DIFF
--- a/test/test_ptz_absolute_move.py
+++ b/test/test_ptz_absolute_move.py
@@ -13,8 +13,6 @@ class MockPTZService:
         self.last_move = None
     def create_type(self, name):
         return SimpleNamespace(ProfileToken=None, Position=None, Velocity=None)
-    if hasattr(SimpleNamespace, 'AbsoluteMove'):
-        pass
     def AbsoluteMove(self, req):
         if self.with_absolute:
             self.last_move = ('Absolute', req)


### PR DESCRIPTION
## Summary
- drop useless `hasattr(SimpleNamespace, 'AbsoluteMove')` block in `test/test_ptz_absolute_move.py`

## Testing
- `pytest test/test_ptz_absolute_move.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685c489923ec832d8c0400c7c9bddc4c