### PR TITLE
Support absolute move in tracker presets

### DIFF
--- a/core/multi_object_ptz_system.py
+++ b/core/multi_object_ptz_system.py
@@ -984,63 +984,71 @@ class MultiObjectPTZTracker:
 
 def create_multi_object_tracker(ip: str, port: int, username: str, password: str,
                                config_name: str = "maritime_standard") -> MultiObjectPTZTracker:
-    """Crear tracker multi-objeto con configuración predefinida"""
-    
+    """Crear tracker multi-objeto con configuración predefinida.
+
+    Cada entrada del diccionario de presets puede incluir el parámetro
+    ``use_absolute_move`` para determinar si el tracker utilizará movimientos
+    absolutos en lugar de continuos.
+    """
+
     # Configuraciones predefinidas
-    configs = {
-        'maritime_standard': MultiObjectConfig(
-            alternating_enabled=True,
-            primary_follow_time=5.0,
-            secondary_follow_time=3.0,
-            auto_zoom_enabled=True,
-            target_object_ratio=0.25,
-            confidence_weight=0.4,
-            movement_weight=0.3,
-            size_weight=0.2,
-            proximity_weight=0.1
-        ),
-        
-        'maritime_fast': MultiObjectConfig(
-            alternating_enabled=True,
-            primary_follow_time=3.0,
-            secondary_follow_time=2.0,
-            auto_zoom_enabled=True,
-            target_object_ratio=0.3,
-            confidence_weight=0.3,
-            movement_weight=0.5,
-            size_weight=0.1,
-            proximity_weight=0.1,
-            max_objects_to_track=4,
-            zoom_speed=0.5
-        ),
-        
-        'surveillance_precise': MultiObjectConfig(
-            alternating_enabled=True,
-            primary_follow_time=8.0,
-            secondary_follow_time=4.0,
-            auto_zoom_enabled=True,
-            target_object_ratio=0.4,
-            confidence_weight=0.6,
-            movement_weight=0.2,
-            size_weight=0.1,
-            proximity_weight=0.1,
-            min_confidence_threshold=0.7,
-            max_objects_to_track=2,
-            zoom_speed=0.2
-        ),
-        
-        'single_object': MultiObjectConfig(
-            alternating_enabled=False,
-            auto_zoom_enabled=True,
-            target_object_ratio=0.35,
-            confidence_weight=0.5,
-            movement_weight=0.3,
-            size_weight=0.2,
-            max_objects_to_track=1
-        )
+    presets = {
+        'maritime_standard': {
+            'alternating_enabled': True,
+            'primary_follow_time': 5.0,
+            'secondary_follow_time': 3.0,
+            'auto_zoom_enabled': True,
+            'target_object_ratio': 0.25,
+            'confidence_weight': 0.4,
+            'movement_weight': 0.3,
+            'size_weight': 0.2,
+            'proximity_weight': 0.1,
+        },
+
+        'maritime_fast': {
+            'alternating_enabled': True,
+            'primary_follow_time': 3.0,
+            'secondary_follow_time': 2.0,
+            'auto_zoom_enabled': True,
+            'target_object_ratio': 0.3,
+            'confidence_weight': 0.3,
+            'movement_weight': 0.5,
+            'size_weight': 0.1,
+            'proximity_weight': 0.1,
+            'max_objects_to_track': 4,
+            'zoom_speed': 0.5,
+        },
+
+        'surveillance_precise': {
+            'alternating_enabled': True,
+            'primary_follow_time': 8.0,
+            'secondary_follow_time': 4.0,
+            'auto_zoom_enabled': True,
+            'target_object_ratio': 0.4,
+            'confidence_weight': 0.6,
+            'movement_weight': 0.2,
+            'size_weight': 0.1,
+            'proximity_weight': 0.1,
+            'min_confidence_threshold': 0.7,
+            'max_objects_to_track': 2,
+            'zoom_speed': 0.2,
+            'use_absolute_move': True,
+        },
+
+        'single_object': {
+            'alternating_enabled': False,
+            'auto_zoom_enabled': True,
+            'target_object_ratio': 0.35,
+            'confidence_weight': 0.5,
+            'movement_weight': 0.3,
+            'size_weight': 0.2,
+            'max_objects_to_track': 1,
+            'use_absolute_move': True,
+        }
     }
-    
-    config = configs.get(config_name, configs['maritime_standard'])
+
+    cfg_dict = presets.get(config_name, presets['maritime_standard'])
+    config = MultiObjectConfig(**cfg_dict)
     return MultiObjectPTZTracker(ip, port, username, password, multi_config=config)
 
 def get_preset_config(config_name: str) -> Optional[MultiObjectConfig]:

--- a/test/test_ptz_absolute_move.py
+++ b/test/test_ptz_absolute_move.py
@@ -5,7 +5,11 @@ import os
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from core.multi_object_ptz_system import MultiObjectPTZTracker, MultiObjectConfig
+from core.multi_object_ptz_system import (
+    MultiObjectPTZTracker,
+    MultiObjectConfig,
+    create_multi_object_tracker,
+)
 
 class MockPTZService:
     def __init__(self, with_absolute=True):
@@ -59,6 +63,20 @@ class AbsoluteMoveTests(unittest.TestCase):
         tracker._send_ptz_command(0.3, 0.1)
         self.assertTrue(tracker.camera.calls)
         self.assertEqual(tracker.camera.calls[0][0], tracker.current_pan_position)
+
+
+class PresetPropagationTests(unittest.TestCase):
+    def test_preset_enables_absolute_move(self):
+        tracker = create_multi_object_tracker(
+            '0.0.0.0', 80, 'u', 'p', 'surveillance_precise'
+        )
+        self.assertTrue(tracker.multi_config.use_absolute_move)
+
+    def test_preset_default_false(self):
+        tracker = create_multi_object_tracker(
+            '0.0.0.0', 80, 'u', 'p', 'maritime_standard'
+        )
+        self.assertFalse(tracker.multi_config.use_absolute_move)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- allow presets passed to `create_multi_object_tracker` to include `use_absolute_move`
- document the new option
- test that presets propagate `use_absolute_move` properly

## Testing
- `pytest test/test_ptz_absolute_move.py -q`
- `pytest test/test_ptz_absolute_move.py::PresetPropagationTests -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests', PyQt6)*

------
https://chatgpt.com/codex/tasks/task_e_685c49719c24832da2ff58a1e66dcb3d